### PR TITLE
Various changes to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
 # Drupal #
 ##########
-docroot/files
-docroot/sites/*/files
-docroot/sites/*/private
+docroot/files/
+docroot/sites/*/files/
+docroot/sites/*/private/
 docroot/sites/*/settings.local.php
-private
+private/
 
 # Packages #
 ############
@@ -32,18 +32,18 @@ Thumbs.db
 .buildpath
 .cache
 .project
-.settings
+.settings/
 .tmproj
-nbproject
+nbproject/
 *.sublime-project
 *.sublime-workspace
 
 # Folders #
 ###########
-.hg
-.svn
-.CVS
-.idea
+.hg/
+.svn/
+.CVS/
+.idea/
 
 # Numerous always-ignore extensions #
 #####################################
@@ -64,7 +64,7 @@ nbproject
 
 
 # Ignore git directories/files in composer plugins #
-vendor/**/.git
-docroot/**/.git
+vendor/**/.git/
+docroot/**/.git/
 vendor/**/.gitattributes
 docroot/**/.gitattributes

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /docroot/sites/*/files/
 /docroot/sites/*/private/
 /docroot/sites/*/settings.local.php
+/docroot/sites/*/settings.php
 /private/
 
 # Packages #

--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,6 @@ nbproject
 *.diff
 *.err
 *.orig
-*.log
 *.rej
 *.swo
 *.swp

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
 # Drupal #
 ##########
-docroot/files/
-docroot/sites/*/files/
-docroot/sites/*/private/
-docroot/sites/*/settings.local.php
-private/
+/docroot/files/
+/docroot/sites/*/files/
+/docroot/sites/*/private/
+/docroot/sites/*/settings.local.php
+/private/
 
 # Packages #
 ############
@@ -40,10 +40,10 @@ nbproject/
 
 # Folders #
 ###########
-.hg/
-.svn/
-.CVS/
-.idea/
+/.hg/
+/.svn/
+/.CVS/
+/.idea/
 
 # Numerous always-ignore extensions #
 #####################################
@@ -60,11 +60,11 @@ nbproject/
 
 # Ignore patches not in the patches directory #
 *.patch
-!patches/*.patch
+!/patches/*.patch
 
 
 # Ignore git directories/files in composer plugins #
-vendor/**/.git/
-docroot/**/.git/
-vendor/**/.gitattributes
-docroot/**/.gitattributes
+/vendor/**/.git/
+/docroot/**/.git/
+/vendor/**/.gitattributes
+/docroot/**/.gitattributes


### PR DESCRIPTION
* Removes a duplicate line.
* Adds more information about the paths we are gitignoring.
* Gitignores `settings.php` because it contains sensitive info.

In addition to these changes, I would suggest gitignoring [directories generated by composer](https://github.com/drupal-composer/drupal-project/blob/ec0f411715/.gitignore#L1-L8), since, if hirak/prestissimo is used, cloning a project that tracks those files offers virtually no speed improvement over adding them post-clone with `composer install`.