### PR TITLE
feature/rm-drupal-console | Remove Drupal Console from composer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,6 @@
     "drupal/coffee": "^1.0",
     "drupal/components": "^2.2",
     "drupal/config_update": "^1.0",
-    "drupal/console": "~1.9",
     "drupal/core": "9.1.10",
     "drupal/core-composer-scaffold": "~9.1.3",
     "drupal/csv_serialization": "^2.0@beta",


### PR DESCRIPTION
Resolves task in Asana to remove Drupal Console.
Removing this since drush takes the place of many Drupal Console tasks.
@mlander we can hold on this if you'd like to review Drupal console first. I think I had to remove it from HAVI when we updated to Drupal 9 bc of deprecations.